### PR TITLE
fixed hostnames

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -67,7 +67,7 @@
         ++ (optionals (length homeModules != 0) [(makeHome homeModules system)]);
     };
 in {
-  desktop = makeSystem {
+  nixos-desktop = makeSystem {
     system = "x86_64-linux";
     modules = [
       ./desktop.nix
@@ -92,7 +92,7 @@ in {
     ];
   };
 
-  laptop = makeSystem {
+  nixos-laptop = makeSystem {
     system = "x86_64-linux";
     modules = [
       ./laptop.nix


### PR DESCRIPTION
changed hostnames to avoid having to specify configuration each time `nixos-rebuild` is executed.